### PR TITLE
ENTESB-14969 Link Secrets Creation page to Quickstarts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,15 +18,15 @@ The most effective way to run this quickstart is to deploy and run the project o
 
 For more details about running this quickstart on a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
-== Running the Quickstart on a single-node Kubernetes/OpenShift cluster
+== Running the Quickstart on a single-node Kubernetese/OpenShift cluster
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
+Both of these products have suitable Fuse images pre-installed.
+If you run it in an environment where those images are not preinstalled follow the steps described in <<single-node-without-preinstalled-images>>.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-To deploy this quickstart to a running single-node OpenShift cluster:
-
-. Download the project and extract the archive on your local filesystem.
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -59,6 +59,54 @@ $ mvn clean -DskipTests oc:deploy -Popenshift
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-cxf-jaxrs-xml` has started up.
 
+[#single-node-without-preinstalled-images]
+=== Running the Quickstart on a single-node Kubernetese/OpenShift cluster without preinstalled images
+
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+
+. Log in to your OpenShift cluster:
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc login -u developer -p developer
+----
+
+. Create a new OpenShift project for the quickstart:
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc new-project MY_PROJECT_NAME
+----
+
+. Configure Red Hat Container Registry authentication (if it is not configured).
+Follow https://access.redhat.com/documentation/en-us/red_hat_fuse/7.9/html-single/fuse_on_openshift_guide/index#configure-container-registry[documentation].
+
+. Import base images in your newly created project (MY_PROJECT_NAME). :
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ oc import-image fuse-java-openshift:1.9 --from=registry.redhat.io/fuse7/fuse-java-openshift:1.9 --confirm
+----
+
+. Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/spring-boot-cxf-jaxrs-xml`) :
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ cd my_openshift/spring-boot-cxf-jaxrs-xml
+----
+
+. Build and deploy the project to the OpenShift cluster:
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -Djkube.generator.from=MY_PROJECT_NAME/fuse-java-openshift:1.9
+----
+
+. In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
+Wait until you can see that the pod for the `spring-boot-cxf-jaxrs-xml` has started up.
+
 == Accessing the CXF JAXRS endpoint
 
 When the example is running, a CXF JAXRS endpoint is available.
@@ -76,15 +124,15 @@ The example provides API documentation of the service using Swagger. You can acc
 
 == Integration Testing
 
-The example includes a https://github.com/fabric8io/fabric8/tree/master/components/fabric8-arquillian[fabric8 arquillian] Kubernetes Integration Test.
-Once the container image has been built and deployed in Kubernetes, the integration test can be run with:
+The example includes a https://github.com/fabric8io/fabric8/tree/master/components/fabric8-arquillian[fabric8 arquillian] Kubernetese Integration Test.
+Once the container image has been built and deployed in Kubernetese, the integration test can be run with:
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 mvn test -Dtest=*KT
 ----
 
-The test is disabled by default and has to be enabled using `-Dtest`. https://fabric8.io/guide/testing.html[Integration Testing] and https://fabric8.io/guide/arquillian.html[Fabric8 Arquillian Extension] provide more information on writing full fledged black box integration tests for Kubernetes.
+The test is disabled by default and has to be enabled using `-Dtest`. https://fabric8.io/guide/testing.html[Integration Testing] and https://fabric8.io/guide/arquillian.html[Fabric8 Arquillian Extension] provide more information on writing full fledged black box integration tests for Kubernetese.
 
 == Running the quickstart standalone on your machine
 
@@ -110,3 +158,7 @@ You can then access the CXF JAXRS endpoint directly from your Web browser, e.g.:
 
 - <http://localhost:8080/services/helloservice/sayHello/FIS>
 will display "Hello FIS, Welcome to CXF RS Spring Boot World!!!"
+
+---
+
+Generated by maven plugin - do NOT edit this file! (See https://github.com/jboss-fuse/documentation-template/blob/main/README.md[documentation])

--- a/src/main/doc/introduction.adoc
+++ b/src/main/doc/introduction.adoc
@@ -1,0 +1,6 @@
+= Spring-Boot Camel CXF JAXRS QuickStart
+
+This example demonstrates how you can use Apache CXF with Spring Boot(xml way to publish the JAXRS endpoint) 
+based on a https://github.com/fabric8io/base-images#java-base-images[fabric8 Java base image].
+
+The quickstart uses Spring Boot to configure a little application that includes a CXF JAXRS endpoint with Swagger enabled.

--- a/src/main/doc/validation-local.adoc
+++ b/src/main/doc/validation-local.adoc
@@ -1,0 +1,5 @@
+
+You can then access the CXF JAXRS endpoint directly from your Web browser, e.g.:
+
+- <http://localhost:8080/services/helloservice/sayHello/FIS>
+will display "Hello FIS, Welcome to CXF RS Spring Boot World!!!"

--- a/src/main/doc/validation-summary.adoc
+++ b/src/main/doc/validation-summary.adoc
@@ -1,0 +1,15 @@
+
+== Accessing the CXF JAXRS endpoint
+
+When the example is running, a CXF JAXRS endpoint is available.
+
+If you run the example on a single-node OpenShift cluster, then the REST service is exposed at 'http://spring-boot-cxf-jaxrs-xml-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/services/helloservice/`.
+
+Notice: As it depends on your OpenShift setup, the hostname (route) might vary. Verify with `oc get routes` which hostname is valid for you.
+
+- <http://spring-boot-cxf-jaxrs-xml-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/services/helloservice/sayHello/FIS>
+will display "Hello FIS, Welcome to CXF RS Spring Boot World!!!"
+
+== Swagger API
+
+The example provides API documentation of the service using Swagger. You can access the API documentation from your Web browser at <http://spring-boot-cxf-jaxrs-xml-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/services/helloservice/openapi.json>.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14969

Change refactors quickstart to use a template for documentation + template adds missing instruction to add secret.